### PR TITLE
Ignore private components

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,7 @@ const svgExporter = async () => {
       process.env.FIGMA_PROJECT_NODE_ID
     ].document.children;
 
-    const svgs = Utils.findAllByValue(children, "COMPONENT");
+    const svgs = Utils.filterComponentStartingWithDot(Utils.findAllByValue(children, "COMPONENT"));
     const numOfSvgs = svgs.length;
 
     console.log("Number of SVGs", numOfSvgs);

--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,7 @@ const svgExporter = async () => {
       process.env.FIGMA_PROJECT_NODE_ID
     ].document.children;
 
-    const svgs = Utils.filterComponentStartingWithDot(Utils.findAllByValue(children, "COMPONENT"));
+    const svgs = Utils.filterPrivateComponents(Utils.findAllByValue(children, "COMPONENT"));
     const numOfSvgs = svgs.length;
 
     console.log("Number of SVGs", numOfSvgs);

--- a/src/util/utils.js
+++ b/src/util/utils.js
@@ -44,8 +44,11 @@ const createFolder = async (path) => {
   }
 };
 
+const filterComponentStartingWithDot = svgs => svgs.filter(({ name }) => !name.startsWith('.'))
+
 exports.writeToFile = writeToFile;
 exports.camelCaseToDash = camelCaseToDash;
 exports.flattenArray = flattenArray;
 exports.findAllByValue = findAllByValue;
 exports.createFolder = createFolder;
+exports.filterComponentStartingWithDot = filterComponentStartingWithDot;

--- a/src/util/utils.js
+++ b/src/util/utils.js
@@ -44,11 +44,11 @@ const createFolder = async (path) => {
   }
 };
 
-const filterComponentStartingWithDot = svgs => svgs.filter(({ name }) => !name.startsWith('.'))
+const filterPrivateComponents = svgs => svgs.filter(({ name }) => !name.startsWith('.') && !name.startsWith('_'))
 
 exports.writeToFile = writeToFile;
 exports.camelCaseToDash = camelCaseToDash;
 exports.flattenArray = flattenArray;
 exports.findAllByValue = findAllByValue;
 exports.createFolder = createFolder;
-exports.filterComponentStartingWithDot = filterComponentStartingWithDot;
+exports.filterPrivateComponents = filterPrivateComponents;

--- a/src/util/utils.test.js
+++ b/src/util/utils.test.js
@@ -19,3 +19,17 @@ describe("Flatten Array", () => {
     expect(Utils.flattenArray(array, 2)).toEqual(result);
   });
 });
+
+describe('Filter Components Starting With a Dot', () => {
+  it('should remove components out of the list that start with a dot', () => {
+    expect(Utils.filterComponentStartingWithDot([
+      { id: '798:3672', name: '.downhill_skiing' },
+      { id: '798:3671', name: 'edit_notifications' },
+      { id: '798:3663', name: '.elderly' },
+      { id: '798:3673', name: 'emoji_emotions' },
+    ])).toEqual([
+      { id: '798:3671', name: 'edit_notifications' },
+      { id: '798:3673', name: 'emoji_emotions' },
+    ])
+  })
+})

--- a/src/util/utils.test.js
+++ b/src/util/utils.test.js
@@ -20,9 +20,10 @@ describe("Flatten Array", () => {
   });
 });
 
-describe('Filter Components Starting With a Dot', () => {
-  it('should remove components out of the list that start with a dot', () => {
-    expect(Utils.filterComponentStartingWithDot([
+describe('Filter Private Components ', () => {
+  it('should remove components out of the list that start with a dot or underscore', () => {
+    expect(Utils.filterPrivateComponents([
+      { id: '798:3673', name: '_circle' },
       { id: '798:3672', name: '.downhill_skiing' },
       { id: '798:3671', name: 'edit_notifications' },
       { id: '798:3663', name: '.elderly' },


### PR DESCRIPTION
First of all, thanks a lot for this tool, it works well and it saved me a lot of time!

We had a requirement that private components should be ignored in the SVG export. In Figma, they are identified by starting the component name with a dot or an underscore.

So I adapted your tool to specifically ignore components starting with a dot or underscore. Let me know if you want to make this an environment variable or at least document it.

[More info from the Figma docs](https://help.figma.com/hc/en-us/articles/360025508373#Create_private_styles_and_components)

<img width="720" alt="Screenshot 2021-03-09 at 18 04 40" src="https://user-images.githubusercontent.com/23064517/110509650-9f738d80-8102-11eb-8665-456a1b093bb0.png">
